### PR TITLE
Allow to specify listen address

### DIFF
--- a/configs/xapsd/xapsd.yaml
+++ b/configs/xapsd/xapsd.yaml
@@ -9,6 +9,7 @@ databaseFile: /var/lib/xapsd/database.json
 
 # xapsd listens ona a socket for http/https requests from the dovecot plugin. This sets the port number of the socket.
 port: 11619
+listenAddr: 127.0.0.1
 
 # xapsd is able to listen on a HTTPS Socket to allow HTTP/2 to be used
 # SSL is enabled implicitly when certfile and keyfile exist
@@ -17,6 +18,7 @@ port: 11619
 tlsCertfile:
 tlsKeyfile:
 tlsPort: 11620
+tlsListenAddr:
 
 # Notifications that are not initiated by new messages are not sent immediately for two reasons:
 # 1. When you move/copy/delete messages you most likely move/copy/delete more messages within a short period of time.

--- a/configs/xapsd/xapsd.yaml
+++ b/configs/xapsd/xapsd.yaml
@@ -7,9 +7,10 @@ loglevel: info
 # This sets the location of the file.
 databaseFile: /var/lib/xapsd/database.json
 
-# xapsd listens ona a socket for http/https requests from the dovecot plugin. This sets the port number of the socket.
+# xapsd listens on a socket for http/https requests from the dovecot plugin.
+# This sets the address and port number of the listen socket.
+listenAddr: '[::1]'
 port: 11619
-listenAddr: 127.0.0.1
 
 # xapsd is able to listen on a HTTPS Socket to allow HTTP/2 to be used
 # SSL is enabled implicitly when certfile and keyfile exist
@@ -17,8 +18,8 @@ listenAddr: 127.0.0.1
 # !!! direct usage with the plugin is discouraged and unsupported
 tlsCertfile:
 tlsKeyfile:
-tlsPort: 11620
 tlsListenAddr:
+tlsPort: 11620
 
 # Notifications that are not initiated by new messages are not sent immediately for two reasons:
 # 1. When you move/copy/delete messages you most likely move/copy/delete more messages within a short period of time.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type (
 		LogLevel              string
 		DatabaseFile          string
 		Port                  string
+		ListenAddr            string
 		CheckInterval         uint
 		Delay                 uint
 		AppleId               string
@@ -20,6 +21,7 @@ type (
 		TlsCertfile           string
 		TlsKeyfile            string
 		TlsPort               string
+		TlsListenAddr         string
 	}
 )
 

--- a/internal/socket.go
+++ b/internal/socket.go
@@ -40,15 +40,15 @@ func NewHttpSocket(config *config.Config, db *database.Database, apns *Apns) {
 	router.POST("/notify", httpSocket.handleNotify)
 	if len(config.TlsCertfile) > 0 || len(config.TlsKeyfile) > 0 {
 		go func() {
-			err := http.ListenAndServeTLS(":"+config.TlsPort, config.TlsCertfile, config.TlsKeyfile, router)
+			err := http.ListenAndServeTLS(config.TlsListenAddr+":"+config.TlsPort, config.TlsCertfile, config.TlsKeyfile, router)
 			if err != nil {
-				log.Fatalf("Could not listen on Port %s: %s", config.TlsPort, err)
+				log.Fatalf("Could not listen on address %s:%s: %s", config.TlsListenAddr, config.TlsPort, err)
 			}
 		}()
 	}
-	err := http.ListenAndServe(":"+config.Port, router)
+	err := http.ListenAndServe(config.ListenAddr+":"+config.Port, router)
 	if err != nil {
-		log.Fatalf("Could not listen on Port %s: %s", config.Port, err)
+		log.Fatalf("Could not listen on address %s:%s: %s", config.ListenAddr, config.Port, err)
 	}
 }
 


### PR DESCRIPTION
This allows to bind to a specific network address, e.g. the loopback interface's address.

New config parameters: listenAddr and tlsListenAddr

They can be set to an IPv4 or IPv6 address.

(Disclaimer: I don't know go, but the change appears to work for me and seems simple enough.)